### PR TITLE
Fix bug in EchoingInput and add missing include

### DIFF
--- a/drivers/archetype/inspect_universe.cc
+++ b/drivers/archetype/inspect_universe.cc
@@ -2,6 +2,7 @@
 #include <sstream>
 #include <iomanip>
 #include <string>
+#include <iterator>
 
 #include "inspect_universe.hh"
 #include "Universe.hh"

--- a/drivers/archetype/update_universe.cc
+++ b/drivers/archetype/update_universe.cc
@@ -20,7 +20,7 @@ namespace archetype {
     { }
 
     virtual char getKey() override {
-      std::string key_str(input_->getKey(), 1);
+      std::string key_str(1, input_->getKey());
       output_->put(key_str);
       return key_str[0];
     }


### PR DESCRIPTION
## Summary
- fix `EchoingInput` single-character echoing
- add `<iterator>` include for `inspect_universe.cc`
- run the C++ test suites

## Testing
- `cmake ../drivers/archetype`
- `make -j2`
- `./archetype --test`

------
https://chatgpt.com/codex/tasks/task_e_684df70392f883308010aa4ea9a7a467