### PR TITLE
Fix typo in bare.ach comment

### DIFF
--- a/games/bare.ach
+++ b/games/bare.ach
@@ -292,7 +292,7 @@ methods
 
 # Here, for the first time in this adventure, we need to follow a message
 # with a method that is more than one statement.  This is done by declaring
-# a compound statment:  a left curly brace, {, followed by any number of
+# a compound statement:  a left curly brace, {, followed by any number of
 # statements (even zero), and right curly brace, }, to finish them off.
 #
 # The other new thing is the >> operator.  Like a comment, it is active


### PR DESCRIPTION
## Summary
- correct a misspelling in a comment within `games/bare.ach`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dfa30d924833083d25c8e054d782d