### PR TITLE
Fix .cpp references in C++ sources

### DIFF
--- a/drivers/archetype/Capture.cc
+++ b/drivers/archetype/Capture.cc
@@ -1,5 +1,5 @@
 //
-//  Capture.cpp
+//  Capture.cc
 //  archetype
 //
 //  Created by Derek Jones on 7/9/14.

--- a/drivers/archetype/ConsoleInput.cc
+++ b/drivers/archetype/ConsoleInput.cc
@@ -1,5 +1,5 @@
 //
-//  ConsoleInput.cpp
+//  ConsoleInput.cc
 //  archetype
 //
 //  Created by Derek Jones on 9/6/14.

--- a/drivers/archetype/Expression.cc
+++ b/drivers/archetype/Expression.cc
@@ -1,5 +1,5 @@
 //
-//  Expression.cpp
+//  Expression.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/10/14.

--- a/drivers/archetype/FileStorage.cc
+++ b/drivers/archetype/FileStorage.cc
@@ -1,5 +1,5 @@
 //
-//  FileStorage.cpp
+//  FileStorage.cc
 //  archetype
 //
 //  Created by Derek Jones on 9/2/14.

--- a/drivers/archetype/Keywords.cc
+++ b/drivers/archetype/Keywords.cc
@@ -1,5 +1,5 @@
 //
-//  Keywords.cpp
+//  Keywords.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/18/14.

--- a/drivers/archetype/Object.cc
+++ b/drivers/archetype/Object.cc
@@ -1,5 +1,5 @@
 //
-//  Object.cpp
+//  Object.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/10/14.

--- a/drivers/archetype/ReadEvalPrintLoop.cc
+++ b/drivers/archetype/ReadEvalPrintLoop.cc
@@ -1,5 +1,5 @@
 //
-//  ReadEvalPrintLoop.cpp
+//  ReadEvalPrintLoop.cc
 //  archetype
 //
 //  Created by Derek Jones on 9/3/14.

--- a/drivers/archetype/Serialization.cc
+++ b/drivers/archetype/Serialization.cc
@@ -1,5 +1,5 @@
 //
-//  Serialization.cpp
+//  Serialization.cc
 //  archetype
 //
 //  Created by Derek Jones on 6/15/14.

--- a/drivers/archetype/SourceFile.cc
+++ b/drivers/archetype/SourceFile.cc
@@ -1,5 +1,5 @@
 //
-//  SourceFile.cpp
+//  SourceFile.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/10/14.

--- a/drivers/archetype/Statement.cc
+++ b/drivers/archetype/Statement.cc
@@ -1,5 +1,5 @@
 //
-//  Statement.cpp
+//  Statement.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/10/14.

--- a/drivers/archetype/SystemObject.cc
+++ b/drivers/archetype/SystemObject.cc
@@ -1,5 +1,5 @@
 //
-//  SystemObject.cpp
+//  SystemObject.cc
 //  archetype
 //
 //  Created by Derek Jones on 4/10/14.

--- a/drivers/archetype/SystemSorter.cc
+++ b/drivers/archetype/SystemSorter.cc
@@ -1,5 +1,5 @@
 //
-//  SystemSorter.cpp
+//  SystemSorter.cc
 //  archetype
 //
 //  Created by Derek Jones on 4/26/14.

--- a/drivers/archetype/TestExpression.cc
+++ b/drivers/archetype/TestExpression.cc
@@ -1,5 +1,5 @@
 //
-//  TestExpression.cpp
+//  TestExpression.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/25/14.

--- a/drivers/archetype/TestIdIndex.cc
+++ b/drivers/archetype/TestIdIndex.cc
@@ -1,5 +1,5 @@
 //
-//  TestIdIndex.cpp
+//  TestIdIndex.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/11/14.

--- a/drivers/archetype/TestObject.cc
+++ b/drivers/archetype/TestObject.cc
@@ -1,5 +1,5 @@
 //
-//  TestObject.cpp
+//  TestObject.cc
 //  archetype
 //
 //  Created by Derek Jones on 3/17/14.

--- a/drivers/archetype/TestRegistry.cc
+++ b/drivers/archetype/TestRegistry.cc
@@ -1,5 +1,5 @@
 //
-//  TestRegistry.cpp
+//  TestRegistry.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/11/14.

--- a/drivers/archetype/TestSerialization.cc
+++ b/drivers/archetype/TestSerialization.cc
@@ -1,5 +1,5 @@
 //
-//  TestSerialization.cpp
+//  TestSerialization.cc
 //  archetype
 //
 //  Created by Derek Jones on 6/17/14.

--- a/drivers/archetype/TestSourceFile.cc
+++ b/drivers/archetype/TestSourceFile.cc
@@ -1,5 +1,5 @@
 //
-//  TestSourceFile.cpp
+//  TestSourceFile.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/11/14.

--- a/drivers/archetype/TestStatement.cc
+++ b/drivers/archetype/TestStatement.cc
@@ -1,5 +1,5 @@
 //
-//  TestStatement.cpp
+//  TestStatement.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/28/14.

--- a/drivers/archetype/TestSystemObject.cc
+++ b/drivers/archetype/TestSystemObject.cc
@@ -1,5 +1,5 @@
 //
-//  TestSystemObject.cpp
+//  TestSystemObject.cc
 //  archetype
 //
 //  Created by Derek Jones on 4/15/14.

--- a/drivers/archetype/TestSystemParser.cc
+++ b/drivers/archetype/TestSystemParser.cc
@@ -1,5 +1,5 @@
 //
-//  TestSystemParser.cpp
+//  TestSystemParser.cc
 //  archetype
 //
 //  Created by Derek Jones on 5/25/14.

--- a/drivers/archetype/TestTokenStream.cc
+++ b/drivers/archetype/TestTokenStream.cc
@@ -1,5 +1,5 @@
 //
-//  TestTokenStream.cpp
+//  TestTokenStream.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/19/14.

--- a/drivers/archetype/TestUniverse.cc
+++ b/drivers/archetype/TestUniverse.cc
@@ -1,5 +1,5 @@
 //
-//  TestUniverse.cpp
+//  TestUniverse.cc
 //  archetype
 //
 //  Created by Derek Jones on 3/22/14.

--- a/drivers/archetype/TestValue.cc
+++ b/drivers/archetype/TestValue.cc
@@ -1,5 +1,5 @@
 //
-//  TestValue.cpp
+//  TestValue.cc
 //  archetype
 //
 //  Created by Derek Jones on 6/30/14.

--- a/drivers/archetype/TestWrappedOutput.cc
+++ b/drivers/archetype/TestWrappedOutput.cc
@@ -1,5 +1,5 @@
 //
-//  TestWrappedOutput.cpp
+//  TestWrappedOutput.cc
 //  archetype
 //
 //  Created by Derek Jones on 9/21/14.

--- a/drivers/archetype/Token.cc
+++ b/drivers/archetype/Token.cc
@@ -1,5 +1,5 @@
 //
-//  Token.cpp
+//  Token.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/10/14.

--- a/drivers/archetype/TokenStream.cc
+++ b/drivers/archetype/TokenStream.cc
@@ -1,5 +1,5 @@
 //
-//  TokenStream.cpp
+//  TokenStream.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/16/14.

--- a/drivers/archetype/Universe.cc
+++ b/drivers/archetype/Universe.cc
@@ -1,5 +1,5 @@
 //
-//  Universe.cpp
+//  Universe.cc
 //  archetype
 //
 //  Created by Derek Jones on 2/10/14.

--- a/drivers/archetype/Value.cc
+++ b/drivers/archetype/Value.cc
@@ -1,5 +1,5 @@
 //
-//  Value.cpp
+//  Value.cc
 //  archetype
 //
 //  Created by Derek Jones on 3/5/14.

--- a/drivers/archetype/Wellspring.cc
+++ b/drivers/archetype/Wellspring.cc
@@ -1,5 +1,5 @@
 //
-//  Wellspring.cpp
+//  Wellspring.cc
 //  archetype
 //
 //  Created by Derek Jones on 6/4/14.


### PR DESCRIPTION
## Summary
- correct file references in headers from `.cpp` to `.cc` in all archetype source files

Fixes leftover template from when I was using Xcode, which preferred `.cpp`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./archetype --help`

------
https://chatgpt.com/codex/tasks/task_e_684dfbd2ae4c8330803ff70bf9a0a287