### PR TITLE
Do not create attributes as a side effect of reading them

### DIFF
--- a/src/Object.cc
+++ b/src/Object.cc
@@ -33,6 +33,10 @@ namespace archetype {
         return attributes_.count(attribute_id) > 0 or (p and p->hasAttribute(attribute_id));
     }
 
+    bool Object::hasLocalAttribute(int attribute_id) const {
+        return attributes_.count(attribute_id) > 0;
+    }
+
     Value Object::getAttributeValue(int attribute_id) const {
         auto where = attributes_.find(attribute_id);
         if (where != attributes_.end()) {

--- a/src/Object.hh
+++ b/src/Object.hh
@@ -62,6 +62,7 @@ namespace archetype {
         ObjectPtr parent() const;
 
         bool hasAttribute(int attribute_id) const;
+        bool hasLocalAttribute(int attribute_id) const;
         Value getAttributeValue(int attribute_id) const;
         void setAttribute(int attribute_id, Expression expr);
         void setAttribute(int attribute_id, Value val);

--- a/src/TestObject.cc
+++ b/src/TestObject.cc
@@ -166,10 +166,29 @@ namespace archetype {
         ARCHETYPE_TEST_EQUAL(actual2, expected2);
     }
 
+    void TestObject::testReadDoesNotMutate_() {
+        ObjectPtr subject = Universe::instance().defineNewObject();
+        Universe::instance().assignObjectIdentifier(subject, "subject");
+        int ghost_id = Universe::instance().Identifiers.index("ghost");
+
+        ARCHETYPE_TEST(not subject->hasAttribute(ghost_id));
+
+        Expression expr = make_expr_from_str("subject.ghost");
+        Value val = expr->evaluate()->valueConversion();
+        ARCHETYPE_TEST(not val->isDefined());
+
+        ARCHETYPE_TEST(not subject->hasAttribute(ghost_id));
+
+        expr->evaluate();
+        expr->evaluate();
+        ARCHETYPE_TEST(not subject->hasAttribute(ghost_id));
+    }
+
     void TestObject::runTests_() {
         testObjects_();
         testInheritance_();
         testMethods_();
         testMessagePassing_();
+        testReadDoesNotMutate_();
     }
 }

--- a/src/TestObject.cc
+++ b/src/TestObject.cc
@@ -182,6 +182,24 @@ namespace archetype {
         expr->evaluate();
         expr->evaluate();
         ARCHETYPE_TEST(not subject->hasAttribute(ghost_id));
+
+        ObjectPtr animal = Universe::instance().defineNewObject();
+        animal->setPrototype(true);
+        Universe::instance().assignObjectIdentifier(animal, "animal");
+        int legs_id = Universe::instance().Identifiers.index("legs");
+        animal->setAttribute(legs_id, Value(new NumericValue(4)));
+
+        ObjectPtr dog = Universe::instance().defineNewObject(animal->id());
+        Universe::instance().assignObjectIdentifier(dog, "dog");
+
+        ARCHETYPE_TEST(dog->hasAttribute(legs_id));
+        ARCHETYPE_TEST(not dog->hasLocalAttribute(legs_id));
+
+        Expression inherited = make_expr_from_str("dog.legs");
+        Value inherited_val = inherited->evaluate()->numericConversion();
+        ARCHETYPE_TEST_EQUAL(inherited_val->getNumber(), 4);
+
+        ARCHETYPE_TEST(not dog->hasLocalAttribute(legs_id));
     }
 
     void TestObject::runTests_() {

--- a/src/TestObject.hh
+++ b/src/TestObject.hh
@@ -19,6 +19,7 @@ namespace archetype {
         void testInheritance_();
         void testMethods_();
         void testMessagePassing_();
+        void testReadDoesNotMutate_();
     protected:
         virtual void runTests_() override;
     public:

--- a/src/Value.cc
+++ b/src/Value.cc
@@ -350,12 +350,8 @@ namespace archetype {
 
     Value AttributeValue::dereference_() const {
         ObjectPtr obj = Universe::instance().getObject(objectId_);
-        if (not obj) {
+        if (not obj or not obj->hasAttribute(attributeId_)) {
             return Value{new UndefinedValue};
-        }
-
-        if (not obj->hasAttribute(attributeId_)) {
-            obj->setAttribute(attributeId_, Value{new UndefinedValue});
         }
 
         ContextScope c;


### PR DESCRIPTION
AttributeValue::dereference_() was calling setAttribute() to stamp an UNDEFINED value onto an object whenever a nonexistent attribute was read. This caused phantom attributes to accumulate over time, inflating save files and polluting the object model. Instead, return UNDEFINED directly without mutation — hasAttribute() already walks the parent chain for inherited lookups.

The setAttribute call was introduced in 4fdcb62 (2014) to make the getAttributeValue() path uniform, but returning early for the not-found case is simpler and avoids the side effect.